### PR TITLE
Easier usage in Dragonfly and Song cleanup

### DIFF
--- a/instruments.go
+++ b/instruments.go
@@ -1,8 +1,55 @@
 package nbs
 
+import (
+	"github.com/df-mc/dragonfly/server/block/instrument"
+	"strconv"
+)
+
+// Instrument is one of the instruments supported through the NBS format.
+type Instrument int
+
+// instrument converts an Instrument to its representation in Dragonfly.
+func (i Instrument) instrument() instrument.Instrument {
+	switch i {
+	case InstrumentHarp:
+		return instrument.Piano()
+	case InstrumentBass:
+		return instrument.Bass()
+	case InstrumentBassDrum:
+		return instrument.BassDrum()
+	case InstrumentSnare:
+		return instrument.Snare()
+	case InstrumentHat:
+		return instrument.ClicksAndSticks()
+	case InstrumentGuitar:
+		return instrument.Guitar()
+	case InstrumentFlute:
+		return instrument.Flute()
+	case InstrumentBell:
+		return instrument.Bell()
+	case InstrumentChime:
+		return instrument.Chimes()
+	case InstrumentXylophone:
+		return instrument.Xylophone()
+	case InstrumentIronXylophone:
+		return instrument.IronXylophone()
+	case InstrumentCowBell:
+		return instrument.CowBell()
+	case InstrumentDidgeridoo:
+		return instrument.Didgeridoo()
+	case InstrumentBit:
+		return instrument.Bit()
+	case InstrumentBanjo:
+		return instrument.Banjo()
+	case InstrumentPling:
+		return instrument.Pling()
+	}
+	panic("unsupported instrument type " + strconv.Itoa(int(i)))
+}
+
 // The following are all supported NBS instruments.
 const (
-	InstrumentHarp uint8 = iota
+	InstrumentHarp Instrument = iota
 	InstrumentBass
 	InstrumentBassDrum
 	InstrumentSnare

--- a/note.go
+++ b/note.go
@@ -1,9 +1,21 @@
 package nbs
 
+import (
+	"github.com/df-mc/dragonfly/server/world/sound"
+)
+
 // Note is a note in a note block song.
 type Note struct {
 	// Instrument is the instrument intended to be used.
-	Instrument uint8
+	Instrument Instrument
 	// Key is the key the note should be played on.
-	Key uint8
+	Key int
+}
+
+// Sound converts the Note to a sound.Note so that it may be played as a soon in Dragonfly.
+func (n Note) Sound() sound.Note {
+	return sound.Note{
+		Instrument: n.Instrument.instrument(),
+		Pitch:      n.Key - 33,
+	}
 }

--- a/player.go
+++ b/player.go
@@ -1,7 +1,74 @@
 package nbs
 
-// Player is an interface that music players can embed and hook onto songs to receive new notes to play as they come in.
-type Player interface {
-	// Play is called when a new note should be played.
-	Play(song *Song, note Note)
+import (
+	"go.uber.org/atomic"
+	"time"
+)
+
+// Player plays a Song. Its field C may be iterated over to obtain Notes from the song whenever a new Note should be
+// played like so:
+//
+//   for note := range Player.C {
+//     fmt.Println(note)
+//   }
+//
+// The channel C will be closed when the song ends or after Player.Stop is called, meaning the loop will end.
+type Player struct {
+	// C receives a Note everytime the Song being played by the Player reaches a point where a note should be played.
+	// C is closed as soon as the song ends or when Player.Stop() is called. It is therefore possible to iterate over
+	// this channel.
+	C <-chan Note
+
+	paused, stopped atomic.Bool
+	// layers contains each layer.
+	layers map[int16]*Layer
+	// length is the length of the song in ticks.
+	length int64
+	// speed is the speed of the song.
+	speed float32
+}
+
+// Stop stops the current song from playing. Stop closes Player.C as soon as the Song reaches its next tick.
+func (p *Player) Stop() {
+	p.stopped.Store(true)
+}
+
+// Pause toggles the pause boolean. If the song is already paused, then it will resume the song. Otherwise, it will
+// pause the song and no new notes will be played.
+func (p *Player) Pause() {
+	p.paused.Toggle()
+}
+
+// run starts running the Player, submitting new Notes to the channel passed.
+func (p *Player) run(c chan Note) {
+	var lastPlayed, tick int64
+	defer close(c)
+	for {
+		if p.stopped.Load() {
+			return
+		}
+
+		notReadyForNextNote := time.Now().UnixNano()/int64(time.Millisecond)-lastPlayed < int64(50*(20/p.speed))
+		if p.paused.Load() || notReadyForNextNote {
+			continue
+		}
+
+		if tick++; tick > p.length {
+			return
+		}
+
+		// Play each note in each layer.
+		for _, l := range p.layers {
+			note, ok := l.Note(tick)
+			if !ok {
+				continue
+			}
+			c <- note
+		}
+
+		// Update the last played time.
+		lastPlayed = time.Now().UnixNano() / int64(time.Millisecond)
+
+		time.Sleep(20 * time.Millisecond)
+	}
 }

--- a/song.go
+++ b/song.go
@@ -20,7 +20,7 @@ type Song struct {
 }
 
 // Play creates a new Player for the Song and starts it.
-func (s *Song) Play() *Player {
+func (s Song) Play() *Player {
 	c := make(chan Note)
 	p := &Player{
 		C:      c,


### PR DESCRIPTION
This PR makes it easier to use nbs in Dragonfly. Additionally, it has some minor cleanups and function renames to get it up to standards. 

I've also split up Song into a new Player and Song so that you can actually re-use Songs easily without having to worry about anything. I've removed the original `Player` interface and changed the way you handle notes to reading from a `<-chan Note` to make it more consistent with stuff like `time.Ticker`s and the like.